### PR TITLE
Typo fixes in examples

### DIFF
--- a/data_tamer/examples/custom_types.cpp
+++ b/data_tamer/examples/custom_types.cpp
@@ -69,19 +69,19 @@ int main()
   Point3D pointB;
   channel->registerValue<Point3D>("pointB", &pointB);
 
-  // complex types like Pose are also supported
+  // Non-trivial types like Pose are also supported
   Pose pose;
   channel->registerValue("my_pose", &pose);
 
-  // Vector can be registered as long as their size will NEVER change
-  // Tour responsivibily to guaranty that!
+  // std::vectors can be registered as long as their size will NEVER change
+  // It is your responsibility to guarantee that!
   std::vector<Point3D> points_vect(5);
   channel->registerValue("points", &points_vect);
 
-  // std::array is also supported (safer than std::vector)
+  // std::array is also supported (safer than std::vector due to constant size)
   std::array<int, 3> value_array;
   channel->registerValue("value_array", &value_array);
 
-  // Print the schema to understand ho they are serialized
+  // Print the schema to understand how they are serialized
   std::cout << channel->getSchema() << std::endl;
 }

--- a/data_tamer/examples/example.cpp
+++ b/data_tamer/examples/example.cpp
@@ -27,11 +27,14 @@ int main()
   [[maybe_unused]] auto id2 = channel->registerValue("value_int", &value_int);
 
   // If you prefer to use RAII, use this method instead
-  // logged_real will disable itself when it goes out of scope.
+  // logged_float will disable itself when it goes out of scope.
   auto logged_float = channel->createLoggedValue<float>("real");
 
   // this is the way you store the current snapshot of the values
   channel->takeSnapshot();
+
+  // you can modify logged_float like this
+  logged_float->set(6.28);
 
   // You can disable a value like this
   channel->setEnabled(id1, false);

--- a/data_tamer/examples/mcap_1m_per_sec.cpp
+++ b/data_tamer/examples/mcap_1m_per_sec.cpp
@@ -53,17 +53,17 @@ void WritingThread(const std::string& channel_name)
 
 int main()
 {
-  // start defining one or more Sinks that must be added by default.
-  // Dp ot BEFORE creating a channel.
+  // Start defining one or more Sinks that must be added by default.
+  // Do this BEFORE creating a channel.
   auto mcap_sink = std::make_shared<MCAPSink>("test_1M.mcap");
   ChannelsRegistry::Global().addDefaultSink(mcap_sink);
 
   // Create (or get) a channel using the global registry (singleton)
   auto channel = ChannelsRegistry::Global().getChannel("chan");
 
-  // each WritingThread has 300 traced values
-  // in total, we will collect 300*4 = 1200 traced values at 1 KHz
-  // for 10 seconds (12 millions data points)
+  // Each WritingThread has 300 traced values.
+  // In total, we will collect 300*4 = 1200 traced values at 1 KHz
+  // for 10 seconds (12 million data points)
   const int N = 4;
   std::thread writers[N];
   for(int i=0; i<N; i++)


### PR DESCRIPTION
First PR :sunglasses:. Just fixes/edits for comments in `examples` and added one more line of code to show how to set the RAII example float.